### PR TITLE
Fix vertex search by pattern only checking '_id'

### DIFF
--- a/graph.ts
+++ b/graph.ts
@@ -121,7 +121,9 @@ export class Graph<V, E> {
 
   public searchVertices(pattern: Partial<VertexProps<V>>): Array<Vertex<V, E> | undefined> {
     if (pattern._id) {
-      return [this.findVertexById(pattern._id)];
+      return [this.findVertexById(pattern._id)]
+        .filter(isDefined)
+        .filter(vertex => objectFilter(vertex, pattern));
     }
 
     // Search for indexed fields first

--- a/query.test.ts
+++ b/query.test.ts
@@ -36,6 +36,7 @@ test('vertex', () => {
   expect(g.v('thor').run()).toHaveLength(1);
   expect(g.v(['thor', 'hoder']).run()).toHaveLength(2);
   expect(g.v({ hair: 'magnificent' }).run()).toHaveLength(2);
+  expect(g.v({ _id: 'balder', hair: 'magnificent' }).run()).toHaveLength(0);
 });
 
 test('in', () => {


### PR DESCRIPTION
Method `searchVertices` in `graph.ts` was returning the vertex with the `_id` specified in the pattern and discarding the other values. Now it also checks if the remaining pattern fields match.